### PR TITLE
Moviendo ipywidgets de environment a requirements

### DIFF
--- a/ararads-base/environment.yml
+++ b/ararads-base/environment.yml
@@ -6,7 +6,7 @@ dependencies:
     - notebook=4.3*
     - jupyterhub=0.7 
     - nomkl 
-    - ipywidgets=5.2* 
+    #- ipywidgets=5.2* 
     - pandas=0.19* 
     - numexpr=2.6* 
     - matplotlib=1.5* 

--- a/ararads-base/requirements.txt
+++ b/ararads-base/requirements.txt
@@ -1,3 +1,4 @@
 graphviz
 tensorflow
 keras
+ipywidgets


### PR DESCRIPTION
¡Hola prof. Juan Pablo!

He encontrado un pequeño error con la librería "ipywidgets" que impedía una compilación exitosa de ararads-base para el curso de Machine Learning con Python en Platzi.

Le dejo para su revisión y comentarios.

Saludos,

Osmandi Gómez